### PR TITLE
Setup bot using environment variables

### DIFF
--- a/setup/bootstrap.sh
+++ b/setup/bootstrap.sh
@@ -19,12 +19,4 @@ if [[ -z "${praw_client_secret}" ]]; then
   exit 1
 fi
 
-# Create the praw environment
-touch /bot/praw.ini
-echo "[bot1]" >> /bot/praw.ini
-echo "client_id=${praw_client_id}" >> /bot/praw.ini
-echo "client_secret=${praw_client_secret}" >> /bot/praw.ini
-echo "password=${praw_password}" >> /bot/praw.ini
-echo "username=${praw_username}" >> /bot/praw.ini
-
 python3 hn_bot


### PR DESCRIPTION
This allows the container to run praw directly without the intermediate step of creating the configuration file based on the environment variables.

This change depends on: https://github.com/qznc/hn_bot/pull/1